### PR TITLE
Remove old deployment files when deploying a new version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
       - name: Push to S3
-        run: aws s3 sync public s3://${{ secrets.AWS_S3_BUCKET }}/ --no-progress
+        run: aws s3 sync public s3://${{ secrets.AWS_S3_BUCKET }}/ --no-progress --delete
       - name: Invalidate Cloudfront cache
         run: aws cloudfront create-invalidation --distribution-id EWJC89C0ACD7D --paths /index.html /*
   


### PR DESCRIPTION
By default, s3 sync does not remove files that don't exist in the origin. This will leave orphaned files in the bucket. This commit solves this issue by telling s3 sync to remove files that are only found in the bucket.