### PR TITLE
Whitelist Free File Fillable Forms

### DIFF
--- a/link_checker.py
+++ b/link_checker.py
@@ -4,7 +4,11 @@ import requests
 
 default_pattern = r"(http[^\n\)]+)"
 latex_link_pattern = r"\\href\{(http[^}]+)\}"
-whitelisted_links = ["https://www.freefilefillableforms.com"]
+
+whitelisted_links = [
+    # This site redirects to a closure page half of the year
+    "https://www.freefilefillableforms.com"
+]
 
 
 class BrokenLinksError(Exception):
@@ -62,9 +66,7 @@ def main():
     links = get_links_from_resumes()
     links.extend(get_links_from_markdown())
 
-    links_to_check = [link for link in links if link not in whitelisted_links]
-
-    broken_links = check_links(set(links_to_check))
+    broken_links = check_links(set([link for link in links if link not in whitelisted_links]))
 
     if len(broken_links) > 0:
         raise BrokenLinksError(broken_links)

--- a/link_checker.py
+++ b/link_checker.py
@@ -4,6 +4,7 @@ import requests
 
 default_pattern = r"(http[^\n\)]+)"
 latex_link_pattern = r"\\href\{(http[^}]+)\}"
+whitelisted_links = ["https://www.freefilefillableforms.com"]
 
 
 class BrokenLinksError(Exception):
@@ -61,7 +62,9 @@ def main():
     links = get_links_from_resumes()
     links.extend(get_links_from_markdown())
 
-    broken_links = check_links(set(links))
+    links_to_check = [link for link in links if link not in whitelisted_links]
+
+    broken_links = check_links(set(links_to_check))
 
     if len(broken_links) > 0:
         raise BrokenLinksError(broken_links)

--- a/link_checker.py
+++ b/link_checker.py
@@ -19,7 +19,7 @@ def get_links_from_file(path, pattern=default_pattern):
     with open(path) as document:
         for line in document:
             links.extend(re.findall(pattern, line))
-    return links
+    return [link.lower() for link in links]
 
 
 def get_links_from_resumes():

--- a/link_checker.py
+++ b/link_checker.py
@@ -23,7 +23,7 @@ def get_links_from_file(path, pattern=default_pattern):
     with open(path) as document:
         for line in document:
             links.extend(re.findall(pattern, line))
-    return [link.lower() for link in links]
+    return links
 
 
 def get_links_from_resumes():

--- a/resume/lucas-kjaero-zhang-resume.tex
+++ b/resume/lucas-kjaero-zhang-resume.tex
@@ -111,7 +111,7 @@ Maintained and expanded an internal tool used to perform all releases in the Tur
 \dates{August 2017-March 2018}
 \title{\textbf{Software Engineer in Quality}}
 \begin{position}
-Designed and expanded test suites for \href{https://www.FreeFileFillableForms.com}{Free File Fillable Forms}, including unit, service, UI, and performance tests as the project's sole quality engineer.
+Designed and expanded test suites for \href{https://www.freefilefillableforms.com}{Free File Fillable Forms}, including unit, service, UI, and performance tests as the project's sole quality engineer.
 % \\
 % \\
 % Participated in all aspects of migrating tax forms between different TurboTax tax engines.


### PR DESCRIPTION
The Free File Fillable Forms link works part of the year, and redirects to a "this site is closed" page the rest of the time. Let's skip checking this link.