### PR TITLE
Increase max open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 100
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
On first run, lots of dependencies are outdated. Let's get rid of the maximum number, so we can get them all opened.