### PR TITLE
Move foreign-language-reader link

### DIFF
--- a/resume/lucas-kjaero-zhang-resume.tex
+++ b/resume/lucas-kjaero-zhang-resume.tex
@@ -124,7 +124,7 @@ Designed and expanded test suites for \href{https://www.freefilefillableforms.co
 
 \par
 \textbf{Foreign Language Reader (in progress)}:
-A website to help language learners transition from textbooks to real text by giving them definitions and examples for whatever they want to read. React frontend with Python and Elixir microservices managed by Kubernetes. Uses Elasticsearch for language content, and Terraform for infrastructure management. \textit{\href{https://github.com/lucaskjaero/foreign-language-reader}{Github}}
+A website to help language learners transition from textbooks to real text by giving them definitions and examples for whatever they want to read. React frontend with Python and Elixir microservices managed by Kubernetes. Uses Elasticsearch for language content, and Terraform for infrastructure management. \textit{\href{https://github.com/foreign-language-reader/foreign-language-reader}{Github}}
 
 \par
 \textbf{MNIST}:


### PR DESCRIPTION
I moved foreign-language reader, so it's time to move the resume link.