### PR TITLE
Kinder build timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   build-frontend:
     name: "Test that frontend builds"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v2.1.4
@@ -62,6 +62,7 @@ jobs:
   test:
     name: "Lint and test frontend"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v2.1.4


### PR DESCRIPTION
Some builds are timing out. Did it get slower? Or is it hanging? Let's find out.