### PR TITLE
Hotfix: allow 10 automated dependency upgrades while 10 need manual fixing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    rebase-strategy: "disabled"
     open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: "daily"
     rebase-strategy: "disabled"
+    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
- Set maximum number of dependabot pull requests to 10.
- Re-enable automatic rebasing. This is normally useful, but starves github action workflows when there are large numbers of requests open.