### PR TITLE
Labeler runs on pull_request_target

### DIFF
--- a/.github/workflows/add_labels.yml
+++ b/.github/workflows/add_labels.yml
@@ -1,0 +1,12 @@
+name: PR Check - Labeler
+
+on: [pull_request_target]
+
+jobs:
+  add-label:
+    name: Add patch label to pull request
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/test_common.yml
+++ b/.github/workflows/test_common.yml
@@ -3,14 +3,6 @@ name: PR Check - Common
 on: [pull_request]
 
 jobs:
-  add-label:
-    name: Add patch label to pull request
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/labeler@v3
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-  
   links:
     name: Check links
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem:
Dependabot cannot access `secrets.GITHUB_TOKEN` on workflows triggered by a `pull_request`. This means it cannot run labeler.

## Solution
Dependabot can be given access by using `pull_request_target` instead.