### PR TITLE
Allow dependabot to merge fixes

### DIFF
--- a/.github/workflows/add_labels.yml
+++ b/.github/workflows/add_labels.yml
@@ -10,3 +10,12 @@ jobs:
     - uses: actions/labeler@v3
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+  
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}


### PR DESCRIPTION
This site is in maintainance mode, and any time I need to change things, dependencies are a hassle. Let's just keep them up to date.