### PR TITLE
Upgrade dependabot PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 20
+    open-pull-requests-limit: 50
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Problem
Some dependency upgrades depend on other ones, and dependabot doesn't always know which ones to do first. It's randomly trying 20 now. There are probably more than 20 dependencies that need upgrades.

## Solution
Increase the limit