### PR TITLE
Remove postcss-nested

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
         "lodash": "^4.17.21",
         "normalize.css": "^8.0.0",
         "postcss-easy-media-query": "^1.0.0",
-        "postcss-nested": "^4.2.3",
         "prismjs": "^1.25.0",
         "prop-types": "^15.7.2",
         "react": "^17.0.2",
@@ -28034,6 +28033,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.2.3.tgz",
       "integrity": "sha512-rOv0W1HquRCamWy2kFl3QazJMMe1ku6rCFoAAH+9AcxdbpDeBr6k968MLWuLjvjMcGEip01ak09hKOEgpK9hvw==",
+      "dev": true,
       "dependencies": {
         "postcss": "^7.0.32",
         "postcss-selector-parser": "^6.0.2"
@@ -28043,6 +28043,7 @@
       "version": "7.0.35",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
       "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+      "dev": true,
       "dependencies": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -28056,6 +28057,7 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
       "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
+      "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "indexes-of": "^1.0.1",
@@ -28070,6 +28072,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -28078,6 +28081,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
       "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -61487,6 +61491,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.2.3.tgz",
       "integrity": "sha512-rOv0W1HquRCamWy2kFl3QazJMMe1ku6rCFoAAH+9AcxdbpDeBr6k968MLWuLjvjMcGEip01ak09hKOEgpK9hvw==",
+      "dev": true,
       "requires": {
         "postcss": "^7.0.32",
         "postcss-selector-parser": "^6.0.2"
@@ -61496,6 +61501,7 @@
           "version": "7.0.35",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
           "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+          "dev": true,
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
@@ -61506,6 +61512,7 @@
           "version": "6.0.4",
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
           "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
+          "dev": true,
           "requires": {
             "cssesc": "^3.0.0",
             "indexes-of": "^1.0.1",
@@ -61516,12 +61523,14 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-obfuscate": "^3.6.8",
     "react-share": "^4.4.0",
     "react-visibility-sensor": "^5.1.1",
-    "styled-jsx": "^4.0.1",
+    "styled-jsx": "^3.4.7",
     "styled-jsx-plugin-postcss": "^0.1.3",
     "styled-jsx-plugin-stylelint": "^0.1.0",
     "tinycolor2": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-obfuscate": "^3.6.8",
     "react-share": "^4.4.0",
     "react-visibility-sensor": "^5.1.1",
-    "styled-jsx": "^3.4.7",
+    "styled-jsx": "^4.0.1",
     "styled-jsx-plugin-postcss": "^0.1.3",
     "styled-jsx-plugin-stylelint": "^0.1.0",
     "tinycolor2": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "lodash": "^4.17.21",
     "normalize.css": "^8.0.0",
     "postcss-easy-media-query": "^1.0.0",
-    "postcss-nested": "^4.2.3",
     "prismjs": "^1.25.0",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -6,6 +6,5 @@ module.exports = (ctx) => ({
         desktop: 1024,
       },
     },
-    "postcss-nested": {},
   },
 });


### PR DESCRIPTION
We use a lot of things from postcss-nested. Let's remove them. Splitting into a new PR because it's a big impact.