### PR TITLE
Recruiter FAQ changes Dec 29

### DIFF
--- a/content/pages/recruiter/index.md
+++ b/content/pages/recruiter/index.md
@@ -6,10 +6,13 @@ I'm a full-stack developer, but I've specialized in data. In general, positions 
 
 Interested in more detail? You can deep dive [by looking at descriptions of some of my work projects](https://www.lucaskjaerozhang.com/project/), or just go straight to [my resume](https://www.lucaskjaerozhang.com/lucas-kjaero-zhang-resume.pdf).
 
-## What is your timeframe?
-I started my last role in early 2021, and am generally happy with my situation. I am unlikely to be interested in switching before 2023. That being said, I'm always happy to connect. 
+## Timeframe
+I started my last role in early 2021, and am generally happy with my situation. I like to stay at companies for at least two years, and therefore am unlikely to be interested in switching before 2023. That being said, I'm always happy to connect. 
 
 ## Types of companies
+### What kind of companies are you most interested in?
+I'm most interested in large tech companies producing software as a service (SAAS) for consumers or businesses. The most important thing is a strong technical culture where engineering craft is nurtured. Bonus points if the business model does not rely on advertising. 
+
 ### Will you be a early employee / technical cofounder of your startup?
 I'm not currently interested in being a part of an early stage startup. While joining a startup is a valuable experience, it's not a good fit for my life stage and appetite for risk. 
 
@@ -21,9 +24,11 @@ Yes, I'm open to contract roles. However, I'm not open to relocating for a contr
 No, I will never need sponsorship to work in the US.
 
 ### Will you need sponsorship now or in the future to work in the EU?
-Short answer: Currently yes, but not in the future. I'm currently under a Danish work visa, and would need sponsorship for any changes. However, I'm also eligible for Danish citizenship. I'm in the process of confirming my status with the Danish government, which will eventually result in an EU passport and no work restrictions. Until that process is complete, I'll continue to need sponsorship within the EU.
+**Short answer: Currently yes, but not in the future.**
 
-## Location.
+I'm currently under a Danish work visa, and would need sponsorship for any changes. However, I'm also eligible for Danish citizenship. I'm in the process of confirming my status with the Danish government, which will eventually result in an EU passport and no work restrictions. Until that process is complete, I'll continue to need sponsorship within the EU.
+
+## Location
 ### Am you open to remote roles?
 Absolutely. I'm in UTC+2 (Central European time), and am open to roles that align with that time zone.
 


### PR DESCRIPTION
Some tweaks to the recruiter FAQ:
- Remove the FAQ from the navigation menu.
- Normalize punctuation.
- Make it clear what kind of roles are good fits, instead of enumerating bad fits.
- TLDR for work authorization.